### PR TITLE
Fix access control specifiers

### DIFF
--- a/Sources/CocoaBarLayout.swift
+++ b/Sources/CocoaBarLayout.swift
@@ -108,7 +108,7 @@ public class CocoaBarLayout: DropShadowView {
     /**
      The dismiss button on the layout
      */
-    @IBOutlet weak var dismissButton: UIButton? {
+    @IBOutlet public weak var dismissButton: UIButton? {
         willSet {
             if let dismissButton = newValue {
                 dismissButton.addTarget(self,
@@ -121,7 +121,7 @@ public class CocoaBarLayout: DropShadowView {
     /**
      The action button on the layout
      */
-    @IBOutlet weak var actionButton: UIButton? {
+    @IBOutlet public weak var actionButton: UIButton? {
         willSet {
             if let actionButton = newValue {
                 actionButton.addTarget(self,

--- a/Sources/Layouts/CocoaBarActionLayout.swift
+++ b/Sources/Layouts/CocoaBarActionLayout.swift
@@ -10,8 +10,8 @@ import UIKit
 
 public class CocoaBarActionLayout: CocoaBarLayout {
     
-    @IBOutlet weak var titleLabel: UILabel?
-    @IBOutlet weak var activityIndicator: UIActivityIndicatorView?
+    @IBOutlet public weak var titleLabel: UILabel?
+    @IBOutlet public weak var activityIndicator: UIActivityIndicatorView?
     
     // MARK: Lifecycle
     

--- a/Sources/Layouts/CocoaBarDefaultLayout.swift
+++ b/Sources/Layouts/CocoaBarDefaultLayout.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-class CocoaBarDefaultLayout: CocoaBarLayout {
+public class CocoaBarDefaultLayout: CocoaBarLayout {
     
-    @IBOutlet weak var titleLabel: UILabel?
+    @IBOutlet public weak var titleLabel: UILabel?
 
-    override func updateLayoutForBackgroundStyle(newStyle: BackgroundStyle, backgroundView: UIView?) {
+    public override func updateLayoutForBackgroundStyle(newStyle: BackgroundStyle, backgroundView: UIView?) {
         switch newStyle {
         case .BlurDark:
             self.titleLabel?.textColor = UIColor.whiteColor()


### PR DESCRIPTION
Fix access control specifiers: namely, the outlets on the layouts should be `public`, as consumers should be allowed to set and configure these.

The demo app already assumes these access control specifiers are set per this PR.

These changes are mainly needed to allow consumption of this library via CocoaPods.

😄 
